### PR TITLE
Pass fully expanded PSQL_ARGS to psql command

### DIFF
--- a/psql2csv
+++ b/psql2csv
@@ -57,4 +57,4 @@ fi
 QUERY=$(echo "$QUERY" | sed 's/;[[:space:]]*$//')
 COMMAND="COPY ($QUERY) TO STDOUT WITH (FORMAT csv, HEADER $HEADER, ENCODING '$ENCODING')"
 
-psql --command="$COMMAND" $PSQL_ARGS
+psql --command="$COMMAND" ${PSQL_ARGS[@]}

--- a/psql2csv
+++ b/psql2csv
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 function usage() {
   echo 'psql2csv: Run a query in psql and output the result as CSV.'


### PR DESCRIPTION
Only the first element was being passed. Furthermore, I also now require bash explicitly since on my system (Ubuntu 14.04) /bin/sh is aliased to /bin/dash, which does not support the  ARR=() syntax.
