### PR TITLE
Use -? instead of -h for help

### DIFF
--- a/psql2csv
+++ b/psql2csv
@@ -13,7 +13,7 @@ function usage() {
   echo '  The query is assumed to be the contents of STDIN, if present, or the last argument.'
   echo '  All other arguments are forwarded to psql except for these:'
   echo
-  echo '  -h, --help             show this help, then exit'
+  echo '  -?, --help             show this help, then exit'
   echo '  --delimiter=DELIMITER  use a different delimiter than comma (e.g. $'"'\\t'"' for tab)'
   echo '  --encoding=ENCODING    use a different encoding than UTF8 (Excel likes LATIN1)'
   echo '  --no-header            do not output a header'
@@ -49,7 +49,7 @@ PSQL_ARGS=()
 while [ $# -gt 0 ]
 do
   case "$1" in
-    --help|-h)     usage; exit;;
+    --help|-?)     usage; exit;;
     --dry-run)     DRY_RUN=true;        shift;;
     --no-header)   HEADER=false;        shift;;
     --delimiter)   DELIMITER="$2";      shift 2;;


### PR DESCRIPTION
As per www.postgresql.org/docs/9.3/static/app-psql.html, `-h HOST` can be used
to specify the DB host. It is confusing when converting a `psql` to `psql2csv` 
command to remember that `-h` prints help and does not specify host!
